### PR TITLE
I've added links to papers and posts on the home page.

### DIFF
--- a/index.md
+++ b/index.md
@@ -22,7 +22,13 @@ I specialize in building and optimizing distributed systems, with deep expertise
 ## Background
 From building Java platforms at Sun Microsystems to scaling distributed systems for fintech companies, I've consistently focused on solving complex technical challenges. My experience spans multiple domains - from telecommunications to financial services to AI infrastructure.
 
+## Papers and Posts
 
+- [compliance-framework](/papers/compliance-framework.html)
+- [compliance-monitoring](/papers/compliance-monitoring.html)
+- [negotiation-framework](/papers/negotiation-framework.html)
+- [operational-risk-appetite](/papers/operational-risk-appetite.html)
+- [latentsync-gcp-mlops](/2024/12/29/latentsync-gcp-mlops.html)
 
 ---
 

--- a/index.md
+++ b/index.md
@@ -22,13 +22,21 @@ I specialize in building and optimizing distributed systems, with deep expertise
 ## Background
 From building Java platforms at Sun Microsystems to scaling distributed systems for fintech companies, I've consistently focused on solving complex technical challenges. My experience spans multiple domains - from telecommunications to financial services to AI infrastructure.
 
-## Papers and Posts
+## Papers
 
-- [compliance-framework](/papers/compliance-framework.html)
-- [compliance-monitoring](/papers/compliance-monitoring.html)
-- [negotiation-framework](/papers/negotiation-framework.html)
-- [operational-risk-appetite](/papers/operational-risk-appetite.html)
-- [latentsync-gcp-mlops](/2024/12/29/latentsync-gcp-mlops.html)
+<ul>
+  {% for paper in site.papers %}
+    <li><a href="{{ paper.url | relative_url }}">{{ paper.title | default: paper.name }}</a></li>
+  {% endfor %}
+</ul>
+
+## Posts
+
+<ul>
+  {% for post in site.posts %}
+    <li><a href="{{ post.url | relative_url }}">{{ post.title }}</a></li>
+  {% endfor %}
+</ul>
 
 ---
 


### PR DESCRIPTION
This change adds a new section to the home page (index.md) that lists available papers from the _papers directory and posts from the _posts directory.

Each item in the list is a link to the respective paper or post, allowing you to easily access these resources directly from the home page.